### PR TITLE
fix link to plural rules

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -185,7 +185,7 @@
               <code>$tabCount</code> variable. The names of the variants,
               <code>[one]</code> and <code>[other]</code>, are standard names
               of the plural categories defined by the Unicode in <a
-              href="http://www.unicode.org/cldr/charts/latest/supplemental/language_plural_rules.html">CLDR</a>.
+              href="http://cldr.unicode.org/index/cldr-spec/plural-rules">CLDR</a>.
 
 
             </p>


### PR DESCRIPTION
Just noticed a minor change in the link and wanted to keep the docs up to date 😃 